### PR TITLE
Changed Webpack hook from 'run' to 'after-plugins' 

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,9 @@ var CreateFilePlugin = (function () {
     const createFile = () => _createFile(this.options.path, this.options.fileName, this.options.content);
 
     if (!!compiler.hooks) {
-      compiler.hooks.done.tap('CreateFileWebpack', createFile());
+      compiler.hooks.afterPlugins.tap('CreateFileWebpack', createFile());
     } else {
-      compiler.plugin('done', createFile());
+      compiler.plugin('after-plugins', createFile());
     }
   };
 


### PR DESCRIPTION
so that the output of this plugin could be used by other plugins (for example by copy-webpack-plugin)